### PR TITLE
Logic Changes

### DIFF
--- a/Business/ChiaPlotsManager.cs
+++ b/Business/ChiaPlotsManager.cs
@@ -42,13 +42,14 @@ namespace chia_plotter.Business.Infrastructure
             var outputChannel = Channel.CreateUnbounded<ChiaPlotOutput>();
             var ignoredDrives = new List<string>();
             var staticText = new StringBuilder();
+            var maxParallelPlotsPerStagger = 1;
             // initialization process to start 2 plots per temp drive
             // don't ignore plot drives but do check plot drives are not on the ignoreDrives list.  This will allow us to have the same temp and dest drive and ignore when full.
-
+// where do I add the logic to stagger?
             foreach (var tempDrive in chiaPlotManagerContextConfiguration.TempPlotDrives) 
             {
                 var destinations = new List<string>();
-                while (destinations.Count != chiaPlotManagerContextConfiguration.PlotsPerDrive)
+                while (destinations.Count < maxParallelPlotsPerStagger)
                 {
                     var destination = chiaPlotManagerContextConfiguration.DestinationPlotDrives.Skip(currentDestinationIndex).FirstOrDefault();
                     if (destination == null)
@@ -129,7 +130,9 @@ namespace chia_plotter.Business.Infrastructure
                         var related = outputs.Where(o => o.TempDrive == output.TempDrive);
                         var completed = related.Where(o => o.IsPlotComplete);
                         var remaining = related.Where(o => !o.IsPlotComplete);
+                        
                         if (remaining.Count() < chiaPlotManagerContextConfiguration.PlotsPerDrive
+                            && remaining.Where(o => string.IsNullOrWhiteSpace(o.CurrentPhase) || (o.CurrentPhase == "1" || o.CurrentPhase == "2")).Count() < maxParallelPlotsPerStagger
                             && completed.Where(c => c.IsTransferComplete == false).Count() < 2)
                         {
                             startNewProcess = true;

--- a/Program.cs
+++ b/Program.cs
@@ -89,7 +89,9 @@ namespace chia_plotter
                         Console.WriteLine(string.Empty.PadRight(50 * 3, '-'), Color.BlueViolet);
                         var avg = outputs.Where(o => o.IsTransferComplete && o.Duration != default).Select(o => o.Duration);
                         var averageTime = TimeSpan.FromSeconds(avg.Any() ? avg.Average(timespan => timespan.TotalSeconds) : 0);
-                        Console.WriteLine($"Completed: {outputs.Where(o => o.IsTransferComplete).Count()} plots with and average time of {averageTime.Hours}:{averageTime.Minutes}:{averageTime.Seconds}");
+                        var skippedTempDrive = outputs.Where(o => o.InvalidDrive == o.TempDrive && o.TempDrive != o.DestinationDrive);
+                        Console.WriteLine($"Completed: {outputs.Where(o => o.IsTransferComplete).Count()} plots with an average time of {averageTime.Hours}:{averageTime.Minutes}:{averageTime.Seconds}");
+                        Console.WriteLine($"Skipped {skippedTempDrive.Count()} temp drive{(skippedTempDrive.Count() != 1 ? "s" : string.Empty)}.");
                         Console.WriteLine(staticTextStringBuilder.ToString());
                     },
                     tempDrive => 

--- a/Program.cs
+++ b/Program.cs
@@ -14,7 +14,7 @@ namespace chia_plotter
     {
         static async Task Main(string[] args)
         {
-            var testing = false;
+            var testing = true;
             var repo = new ChiaPlotProcessRepository();
             try
             {
@@ -28,22 +28,29 @@ namespace chia_plotter
                 };
                 config.DestinationPlotDrives = new List<string>() 
                 { 
-                    "/chia/plots/100", 
-                    "/chia/plots/101", 
-                    "/chia/plots/102", 
-                    "/chia/plots/103", 
-                    "/chia/plots/104", 
-                    "/chia/plots/105", 
-                    "/chia/plots/106", 
-                    "/chia/plots/107", 
-                    "/chia/plots/108", 
-                    "/chia/plots/109" 
+                    // "/chia/plots/100", 
+                    // "/chia/plots/101", 
+                    // "/chia/plots/102", 
+                    // "/chia/plots/103", 
+                    // "/chia/plots/104", 
+                    // "/chia/plots/105", 
+                    // "/chia/plots/106", 
+                    // "/chia/plots/107", 
+                    // "/chia/plots/108", 
+                    // "/chia/plots/109" 
+                    "/chia/plots/200", 
+                    "/chia/plots/201",
+                    //  "/chia/plots/202", 
+                    // "/chia/plots/203",
+                    //  "/chia/plots/204",
+                    "/chia/plots/205",
+                    "/chia/plots/206",
                 };
                 config.KSizes = new List<KSizeMetadata>
                 { 
-                    new KSizeMetadata { PlotSize = 408000000000, WorkSize = 1000000000, K = "34", Threads = 8, Ram = 15000 }, 
-                    new KSizeMetadata { PlotSize = 208000000000, WorkSize = 550000000, K = "33", Threads = 4, Ram = 10000 }, 
-                    new KSizeMetadata { PlotSize = 108000000000, WorkSize = 280000000, K = "32", Threads = 2, Ram = 5000 } 
+                    new KSizeMetadata { PlotSize = 408000000000, WorkSize = 1000000000, K = "34", Threads = 4, Ram = 8000 }, 
+                    new KSizeMetadata { PlotSize = 208000000000, WorkSize = 550000000, K = "33", Threads = 4, Ram = 6000 }, 
+                    new KSizeMetadata { PlotSize = 108000000000, WorkSize = 280000000, K = "32", Threads = 2, Ram = 4000 } 
                 };
             
                 var manager = new ChiaPlotsManager(


### PR DESCRIPTION
1) Removed temp drives from being added to the ignore list unless they are a destination drive as well.
2) Added staggered starts where the total number of parallel plots set per temp drive is divided by 2 called Y.  Y number of plots is started and Y more will start when the first half reaches phase 2.  Example;  I have 2 TB temp drive so I run 8 k32s in parallel.  4 will start immediately.  When any one of those 4 make it past phase 2, another plot process will start, up to 8.